### PR TITLE
v0.1.0 release 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,12 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager 
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 # distroless cannot run `kubeadm upgrade apply` smoothly
 # FROM gcr.m.daocloud.io/distroless/static:nonroot
-FROM docker.m.daocloud.io/ubuntu
-RUN apt-get update -q -y && apt-get install -q -y curl && apt clean all
 
+# ubuntu based operation image is about 158MiB 72.8MiB.
+# FROM docker.m.daocloud.io/ubuntu
+
+FROM k8s-gcr.m.daocloud.io/debian-base:v1.0.0
+RUN apt-get update -q -y && apt-get install -q -y curl && apt clean all
 WORKDIR /
 COPY --from=builder /workspace/manager .
 # USER nonroot:nonroot

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # Image URL to use all building/pushing image targets
-IMG ?= daocloud.io/daocloud/kubeadm-operator:v0.0.5-dev
+IMG ?= daocloud.io/daocloud/kubeadm-operator:v0.1.0
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd"
 

--- a/api/v1alpha1/command_descriptor_types.go
+++ b/api/v1alpha1/command_descriptor_types.go
@@ -102,7 +102,6 @@ type KubeadmUpgradeKubeProxySpec struct {
 	KubernetesVersion string `json:"kubernetesVersion"`
 }
 
-// TODO download the specified version bin and replace it in the node
 // KubeadmUpgradeNodeCommandSpec provides...
 type KubeadmUpgradeNodeCommandSpec struct {
 	// for dry run mode
@@ -132,7 +131,6 @@ type KubectlUncordonCommandSpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
-// TODO download the specified version bin and replace it in the node
 // UpgradeKubeletAndKubeactlCommandSpec provides...
 type UpgradeKubeletAndKubeactlCommandSpec struct {
 	// KubernetesVersion specifies the target kubernetes version

--- a/commands/kubeadm_config_image_pull.go
+++ b/commands/kubeadm_config_image_pull.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+
+	operatorv1 "k8s.io/kubeadm/operator/api/v1alpha1"
+)
+
+func runKubeadmConfigImagePull(spec *operatorv1.KubeadmUpgradeNodeCommandSpec, log logr.Logger) error {
+	var cmd *cmd
+
+	cmd = newCmd("kubeadm", "config", "image", "pull")
+
+	lines, err := cmd.RunAndCapture()
+	if err != nil {
+		return errors.WithStack(errors.WithMessage(err, strings.Join(lines, "\n")))
+	}
+
+	log.Info(fmt.Sprintf("%s", strings.Join(lines, "\n")))
+
+	return nil
+}

--- a/commands/upgrade_kubeadm.go
+++ b/commands/upgrade_kubeadm.go
@@ -71,7 +71,7 @@ func runUpgradeKubeadm(spec *operatorv1.UpgradeKubeadmCommandSpec, log logr.Logg
 		return err
 	}
 
-	cmd := newCmd("/usr/bin/cp", "-f", "/usr/bin/kubeadm-"+spec.KubernetesVersion, "/usr/bin/kubeadm")
+	cmd := newCmd("cp", "-f", "/usr/bin/kubeadm-"+spec.KubernetesVersion, "/usr/bin/kubeadm")
 	start, err := cmd.RunAndCapture()
 	if err != nil {
 		return errors.WithStack(errors.WithMessage(err, strings.Join(start, "\n")))

--- a/commands/upgrade_kubectlkubelet.go
+++ b/commands/upgrade_kubectlkubelet.go
@@ -46,7 +46,7 @@ func runUpgradeKubectlAndKubelet(spec *operatorv1.UpgradeKubeletAndKubeactlComma
 		// upgrade can skip kubectl upgrade
 		log.Info("kubectl upgrade is not significant, so skip")
 	}
-	cmd := newCmd("/usr/bin/cp", "-f", "/usr/bin/kubectl-"+spec.KubernetesVersion, "/usr/bin/kubectl")
+	cmd := newCmd("cp", "-f", "/usr/bin/kubectl-"+spec.KubernetesVersion, "/usr/bin/kubectl")
 	start, err := cmd.RunAndCapture()
 	if err != nil {
 		return errors.WithStack(errors.WithMessage(err, strings.Join(start, "\n")))
@@ -65,7 +65,7 @@ func runUpgradeKubectlAndKubelet(spec *operatorv1.UpgradeKubeletAndKubeactlComma
 	}
 
 	// see https://github.com/pacoxu/kubelet-reloader/ to add a daemon or service on nodes to replace kubelet and restart kubelet.
-	cmd = newCmd("/usr/bin/cp", "-f", "/usr/bin/kubelet-"+spec.KubernetesVersion, "/usr/bin/kubelet-new")
+	cmd = newCmd("cp", "-f", "/usr/bin/kubelet-"+spec.KubernetesVersion, "/usr/bin/kubelet-new")
 	start, err = cmd.RunAndCapture()
 	if err != nil {
 		return errors.WithStack(errors.WithMessage(err, strings.Join(start, "\n")))

--- a/config/crd/bases/operator.kubeadm.x-k8s.io_operations.yaml
+++ b/config/crd/bases/operator.kubeadm.x-k8s.io_operations.yaml
@@ -267,9 +267,8 @@ spec:
                                             - kubernetesVersion
                                             type: object
                                           kubeadmUpgradeNode:
-                                            description: TODO download the specified
-                                              version bin and replace it in the node
-                                              KubeadmUpgradeNodeCommandSpec provides...
+                                            description: KubeadmUpgradeNodeCommandSpec
+                                              provides...
                                             properties:
                                               dryRun:
                                                 description: for dry run mode
@@ -322,9 +321,7 @@ spec:
                                                 type: boolean
                                             type: object
                                           upgradeKubeletAndKubeactl:
-                                            description: TODO download the specified
-                                              version bin and replace it in the node
-                                              UpgradeKubeletAndKubeactlCommandSpec
+                                            description: UpgradeKubeletAndKubeactlCommandSpec
                                               provides...
                                             properties:
                                               kubernetesVersion:

--- a/config/crd/bases/operator.kubeadm.x-k8s.io_runtimetaskgroups.yaml
+++ b/config/crd/bases/operator.kubeadm.x-k8s.io_runtimetaskgroups.yaml
@@ -220,9 +220,7 @@ spec:
                               - kubernetesVersion
                               type: object
                             kubeadmUpgradeNode:
-                              description: TODO download the specified version bin
-                                and replace it in the node KubeadmUpgradeNodeCommandSpec
-                                provides...
+                              description: KubeadmUpgradeNodeCommandSpec provides...
                               properties:
                                 dryRun:
                                   description: for dry run mode
@@ -269,9 +267,7 @@ spec:
                                   type: boolean
                               type: object
                             upgradeKubeletAndKubeactl:
-                              description: TODO download the specified version bin
-                                and replace it in the node UpgradeKubeletAndKubeactlCommandSpec
-                                provides...
+                              description: UpgradeKubeletAndKubeactlCommandSpec provides...
                               properties:
                                 kubernetesVersion:
                                   description: KubernetesVersion specifies the target

--- a/config/crd/bases/operator.kubeadm.x-k8s.io_runtimetasks.yaml
+++ b/config/crd/bases/operator.kubeadm.x-k8s.io_runtimetasks.yaml
@@ -100,8 +100,7 @@ spec:
                       - kubernetesVersion
                       type: object
                     kubeadmUpgradeNode:
-                      description: TODO download the specified version bin and replace
-                        it in the node KubeadmUpgradeNodeCommandSpec provides...
+                      description: KubeadmUpgradeNodeCommandSpec provides...
                       properties:
                         dryRun:
                           description: for dry run mode
@@ -146,8 +145,7 @@ spec:
                           type: boolean
                       type: object
                     upgradeKubeletAndKubeactl:
-                      description: TODO download the specified version bin and replace
-                        it in the node UpgradeKubeletAndKubeactlCommandSpec provides...
+                      description: UpgradeKubeletAndKubeactlCommandSpec provides...
                       properties:
                         kubernetesVersion:
                           description: KubernetesVersion specifies the target kubernetes

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: daocloud.io/daocloud/kubeadm-operator
-  newTag: v0.0.5-dev
+  newTag: v0.1.0

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -39,7 +39,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-        image: daocloud.io/daocloud/kubeadm-operator:v0.0.5-dev
+        image: daocloud.io/daocloud/kubeadm-operator:v0.1.0
         name: manager
         resources:
           limits:

--- a/controllers/util.go
+++ b/controllers/util.go
@@ -188,11 +188,6 @@ func createDaemonSet(c client.Client, operation *operatorv1.Operation, namespace
 									Name:      "crictl",
 									MountPath: "/usr/local/bin/crictl",
 								},
-								// cp is used by kubeadm upgrade apply to run command like `cp`
-								{
-									Name:      "cp",
-									MountPath: "/usr/bin/cp",
-								},
 								{
 									Name:      "etc-kubernetes",
 									MountPath: "/etc/kubernetes",
@@ -284,15 +279,6 @@ func createDaemonSet(c client.Client, operation *operatorv1.Operation, namespace
 								HostPath: &corev1.HostPathVolumeSource{
 									Path: "/usr/local/bin/crictl",
 									Type: hostPathTypePtr(corev1.HostPathFileOrCreate),
-								},
-							},
-						},
-						{
-							Name: "cp",
-							VolumeSource: corev1.VolumeSource{
-								HostPath: &corev1.HostPathVolumeSource{
-									Path: "/usr/bin/cp",
-									Type: hostPathTypePtr(corev1.HostPathFile),
 								},
 							},
 						},

--- a/operations/factory.go
+++ b/operations/factory.go
@@ -47,7 +47,7 @@ func TaskGroupList(operation *operatorv1.Operation, c client.Client) (*operatorv
 	}
 
 	if operation.Spec.Upgrade != nil {
-		return planUpgrade(operation, operation.Spec.Upgrade, c), nil
+		return planUpgrade(operation, operation.Spec.Upgrade, c)
 	}
 
 	if operation.Spec.CustomOperation != nil {

--- a/operations/upgrade.go
+++ b/operations/upgrade.go
@@ -156,7 +156,9 @@ func planNextUpgrade(operation *operatorv1.Operation, version string, c client.C
 		log.Info("failed to list nodes.", "error", err)
 		return items
 	}
-	if len(cpNodes.Items) > 1 {
+	// Workaround: if isServerCanSkip, the only server's kubelet may need to upgrade.
+	// TODO to make more accurate task, we may cut tasks into small ones, for instance, upgrade kubelet only.
+	if len(cpNodes.Items) > 1 || isServerCanSkip {
 
 		t2.Spec.Template.Spec.Commands = append(t2.Spec.Template.Spec.Commands,
 			operatorv1.CommandDescriptor{

--- a/operations/version.go
+++ b/operations/version.go
@@ -22,6 +22,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/version"
 )
 
+// by default, we use v1.x.0 directly, but if there is a prefered version, we use it
+var preferedKubeadmVersion = map[uint]string{
+	// TODO change the version to lastest version after https://github.com/kubernetes/kubeadm/issues/2426(a bug in v1.24) is fixed
+	24: "v1.24.2",
+}
+
 func upgradeCheck(current, target string) (isSupported, isCrossVersion, canSkip bool) {
 	currentVer, err := version.ParseSemantic(current)
 	if err != nil {
@@ -97,7 +103,15 @@ func getCrossVersions(current, target string) []string {
 	}
 	tarMinor := tar.Minor()
 	for i := cur.Minor() + 1; i < tarMinor; i++ {
-		versions = append(versions, fmt.Sprintf("v1.%d.0", i))
+		version := getPerferedVersion(i)
+		versions = append(versions, version)
 	}
 	return versions
+}
+
+func getPerferedVersion(minor uint) string {
+	if preferedKubeadmVersion[minor] != "" {
+		return preferedKubeadmVersion[minor]
+	}
+	return fmt.Sprintf("v1.%d.0", minor)
 }


### PR DESCRIPTION
- [use debian instead of ubuntu as base image](https://github.com/pacoxu/kubeadm-operator/commit/a066f3c8b9f0053824aa653c3c1e33720c7754de)
- [add step of kubeadm config image pull](https://github.com/pacoxu/kubeadm-operator/commit/71fb6ab9becfc5408e22ec24a0c91b087e0599cd) 
- [fix](https://github.com/pacoxu/kubeadm-operator/commit/9d6523e7e8eae1d5fc69e7a89329011d48de7f1a) https://github.com/pacoxu/kubeadm-operator/issues/74[: upgrade node if only one control plane as a workaround](https://github.com/pacoxu/kubeadm-operator/commit/9d6523e7e8eae1d5fc69e7a89329011d48de7f1a)
